### PR TITLE
Teach hangouts-notifier about the chat frames in gmail

### DIFF
--- a/hangouts-notifier/hangouts-notifier.user.js
+++ b/hangouts-notifier/hangouts-notifier.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hangouts Notifier
 // @namespace    fuzetsu.com/HangoutsNotifier
-// @version      0.0.8
+// @version      0.0.9
 // @description  Show desktop notifications for the Hangouts web app
 // @author       fuzetsu
 // @match        https://hangouts.google.com/webchat/*
@@ -96,7 +96,12 @@ var hn = {
     var res = hn.getLastMessage();
     if (!res) {
       util.log('failed to get last message, this probably  isn\'t a hangouts chat window...');
-      return false;
+      if (document.URL.indexOf('prop=gmail#epreld') >= 0) {
+        util.log('So it may be a hangouts chat window, after all...');
+        res = {id: -1};
+      } else {
+        return false;
+      }
     }
     // if window is focused set last message as read
     if (document.hasFocus() || !util.q(NEW_MSG)) {


### PR DESCRIPTION
Even if we don't find a message, keep pooling frames with 'prop=gmail#epreld' in the URL.
All I can say is it works for me. It's dirty (maybe too much to merge), seems too brittle and clings to one non-chat iframe. It may or may not be extended in the same fashion for other google apps that connect to hangouts.