### PR TITLE
Fix playlists with live videos

### DIFF
--- a/youtube-playlist-time/youtube-playlist-time.user.js
+++ b/youtube-playlist-time/youtube-playlist-time.user.js
@@ -100,7 +100,7 @@ const calcTotalTime = (force = false) => {
   const timestamps = util.qq(TIMESTAMP_SELECTOR)
   if (!force && timestamps.length === lastLength && timeLocExists()) return
   lastLength = timestamps.length
-  const totalSeconds = timestamps.reduce(function (total, ts) {
+  const totalSeconds = timestamps.filter(ts => ts.textContent.trim() !== 'LIVE').reduce(function (total, ts) {
     return total + calcTimeString(ts.textContent.trim())
   }, 0)
   setTime(totalSeconds)


### PR DESCRIPTION
This pull request fixes playlists that contain live videos by excluding videos with the duration `LIVE`.