### PR TITLE
Speed up ads.

### DIFF
--- a/auto-close-youtube-ads/auto-close-youtube-ads.user.js
+++ b/auto-close-youtube-ads/auto-close-youtube-ads.user.js
@@ -226,6 +226,26 @@ function getAdLength(ad) {
   return time ? parseTime(time.textContent) : 0
 }
 
+function speedUp() {
+  const vid = document.getElementsByTagName("video")
+  if (vid) {
+    util.log('Speeding up video')
+    vid[0].playbackRate = 16
+  } else {
+    util.log('Couldn\'t find video to speed up')
+  }
+}
+
+function slowDown() {
+  const vid = document.getElementsByTagName("video")
+  if (vid) {
+    util.log('Setting video speed to 1')
+    vid[0].playbackRate = 1
+  } else {
+    util.log('Couldn\'t find video to change speed')
+  }
+}
+
 function waitForAds() {
   DONT_SKIP = false
   TICKS.push(
@@ -281,14 +301,17 @@ function waitForAds() {
         const muteIndicator = getMuteIndicator()
         if (!muteIndicator) return util.log('unable to determine mute state, skipping mute')
         muteButton.click()
+        speedUp()
         util.log('Video ad detected, muting audio')
         // wait for the ad to disappear before unmuting
         util.keepTrying(250, () => {
           if (!util.q(CSS.adArea)) {
             if (isMuted(muteIndicator)) {
               muteButton.click()
+              slowDown()
               util.log('Video ad ended, unmuting audio')
             } else {
+              slowDown()
               util.log('Video ad ended, audio already unmuted')
             }
             return true


### PR DESCRIPTION
Here is something that's been working for me recently. I found this script on greasyfork once my previous one stopped working. It's been reliable so far thank you!

When we can't skip ads then speed them up.

What it should do but currently doesn't (and if you are motivated to add this stuff then please do so, it's working fine for me as-is so I likely won't bother):
* have a related config item or two
* don't force x1 speed when coming out of an ad but remember what it was before speeding up