### PR TITLE
Fix playlists containing videos without duration

### DIFF
--- a/youtube-playlist-time/youtube-playlist-time.user.js
+++ b/youtube-playlist-time/youtube-playlist-time.user.js
@@ -100,7 +100,7 @@ const calcTotalTime = (force = false) => {
   const timestamps = util.qq(TIMESTAMP_SELECTOR)
   if (!force && timestamps.length === lastLength && timeLocExists()) return
   lastLength = timestamps.length
-  const totalSeconds = timestamps.filter(ts => ts.textContent.trim() !== 'LIVE').reduce(function (total, ts) {
+  const totalSeconds = timestamps.filter(ts => ts.textContent.trim().search(":") > 0).reduce(function (total, ts) {
     return total + calcTimeString(ts.textContent.trim())
   }, 0)
   setTime(totalSeconds)


### PR DESCRIPTION
This pull request checks for valid video durations when calculating total playing time. Previously the text "LIVE" was checked for but it can also be "UPCOMING" and possibly others. The fix has been copied from [here](https://greasyfork.org/en/scripts/694-youtube-playlist-time/discussions/135452).