### PR TITLE
Fix yt-formatted-string style

### DIFF
--- a/youtube-playlist-time/youtube-playlist-time.user.js
+++ b/youtube-playlist-time/youtube-playlist-time.user.js
@@ -87,6 +87,7 @@ const getTimeLoc = function () {
   let loc = util.q('#' + EL_ID)
   if (!loc) {
     loc = util.q(HOLDER_SELECTOR).appendChild(document.createElement(EL_TYPE))
+    loc.removeAttribute('is-empty')
     loc.id = EL_ID
     loc.className = EL_CLASS
   }

--- a/youtube-playlist-time/youtube-playlist-time.user.js
+++ b/youtube-playlist-time/youtube-playlist-time.user.js
@@ -10,7 +10,7 @@
 // ==/UserScript==
 
 const SCRIPT_NAME = 'YouTube Playlist Time'
-const HOLDER_SELECTOR = '#stats'
+const HOLDER_SELECTOR = '.metadata-stats'
 const TIMESTAMP_SELECTOR =
   'ytd-browse:not([hidden]) span.ytd-thumbnail-overlay-time-status-renderer'
 const EL_ID = 'us-total-time'


### PR DESCRIPTION
This pull request removes the `is-hidden` attribute that results in the element being hidden, it is added automatically when the `yt-formatted-string` element is created.

The holder selector was also changed later. 