### PR TITLE
Fix Chrome TypeError

### DIFF
--- a/youtube-playlist-time/youtube-playlist-time.user.js
+++ b/youtube-playlist-time/youtube-playlist-time.user.js
@@ -18,6 +18,12 @@ const EL_ID = 'us-total-time'
 const EL_TYPE = 'yt-formatted-string'
 const EL_CLASS = 'style-scope ytd-playlist-sidebar-primary-info-renderer'
 
+if (!window.trustedTypes.defaultPolicy) {
+  window.trustedTypes.createPolicy('default', {
+    createHTML: (input) => input
+  });
+}
+
 const util = {
   log() {
     const args = [].slice.call(arguments)


### PR DESCRIPTION
This fixes the following error on Chrome, which prevented the script from working:

```
TypeError: Failed to set the 'innerHTML' property on 'Element': This document requires 'TrustedHTML' assignment.
```